### PR TITLE
WDP-2505-01 Bugfix: Dodano hover do FeatureBox i usunięto klasę active

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.js
+++ b/src/components/common/FeatureBox/FeatureBox.js
@@ -1,19 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './FeatureBox.module.scss';
 
 const FeatureBox = ({ icon, children }) => (
-  <a href='#' className={styles.root}>
+  <Link to='#' className={styles.root}>
     {icon && (
       <div className={styles.iconWrapper}>
         <FontAwesomeIcon className={styles.icon} icon={icon} />
       </div>
     )}
     <div className={styles.content}>{children}</div>
-  </a>
+  </Link>
 );
 
 FeatureBox.propTypes = {

--- a/src/components/common/FeatureBox/FeatureBox.js
+++ b/src/components/common/FeatureBox/FeatureBox.js
@@ -5,21 +5,20 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './FeatureBox.module.scss';
 
-const FeatureBox = ({ active, icon, children }) => (
-  <div className={styles.root + (active ? ' ' + styles.active : '')}>
+const FeatureBox = ({ icon, children }) => (
+  <a href='#' className={styles.root}>
     {icon && (
       <div className={styles.iconWrapper}>
         <FontAwesomeIcon className={styles.icon} icon={icon} />
       </div>
     )}
     <div className={styles.content}>{children}</div>
-  </div>
+  </a>
 );
 
 FeatureBox.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.object,
-  active: PropTypes.bool,
 };
 
 export default FeatureBox;

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -7,16 +7,22 @@
   margin-top: 40px;
 
   &:hover {
-    border-color: $primary;
+    border-color: b6b6b6;
+    text-decoration: none;
 
     .content {
-    color: $primary;
+      color: $primary;
     }
 
     .iconWrapper {
-      color: $primary;
+      color: white;
 
       &::after {
+        border-color: $primary;
+        background-color: $primary;
+      }
+
+      &::before {
         border-color: $primary;
       }
     }

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -7,7 +7,7 @@
   margin-top: 40px;
 
   &:hover {
-    border-color: b6b6b6;
+    border-color: #b6b6b6;
     text-decoration: none;
 
     .content {
@@ -15,7 +15,7 @@
     }
 
     .iconWrapper {
-      color: white;
+      color: #ffffff;
 
       &::after {
         border-color: $primary;

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -1,9 +1,26 @@
 @import "../../../styles/settings.scss";
 
 .root {
+  display: block;
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+
+  &:hover {
+    border-color: $primary;
+
+    .content {
+    color: $primary;
+    }
+
+    .iconWrapper {
+      color: $primary;
+
+      &::after {
+        border-color: $primary;
+      }
+    }
+  }
 
   .iconWrapper {
     height: 60px;
@@ -49,6 +66,7 @@
     text-transform: uppercase;
     color: rgb(42, 42, 42);
     margin-top: -0.5rem;
+    padding: 1rem 0;
     letter-spacing: 1px;
     font-weight: 300;
 
@@ -61,18 +79,4 @@
     }
   }
 
-  &.active {
-    .iconWrapper {
-      color: #ffffff;
-
-      &::after {
-        background-color: $primary;
-        border-color: $primary;
-      }
-    }
-
-    .content {
-      color: $primary;
-    }
-  }
 }

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -16,7 +16,7 @@ const FeatureBoxes = () => (
     <div className='container'>
       <div className='row'>
         <div className='col'>
-          <FeatureBox icon={faTruck} active>
+          <FeatureBox icon={faTruck}>
             <h5>Free shipping</h5>
             <p>All orders</p>
           </FeatureBox>


### PR DESCRIPTION
Co było nie tak?
Pierwszy z czterech elementów ("Free shipping") miał na stałe ustawioną klasę `.active`. Przez to zawsze był wyróżniony – nawet gdy użytkownik nie najechał na niego kursorem. Pozostałe elementy w ogóle nie miały efektu hover.

Co zrobiłem?
- Usunąłem klasę `.active` z pierwszego elementu
- Zmodyfikowałem komponent `FeatureBox` tak, żeby każdy element był linkiem (`<a>`)
- W pliku SCSS (`FeatureBox.module.scss`) dodałem efekt hover dla `.root`, `.content`, `.iconWrapper`, `.iconWrapper::after`