### PR TITLE
WDP-2505-01 Bugfix: Stylowanie aktywnych stanów przycisków w ProductBox

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -11,7 +11,7 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 
-const ProductBox = ({ name, price, promo, stars }) => (
+const ProductBox = ({ name, price, promo, stars, isFavorite, isCompared }) => (
   <div className={styles.root}>
     <div className={styles.photo}>
       {promo && <div className={styles.sale}>{promo}</div>}
@@ -39,10 +39,10 @@ const ProductBox = ({ name, price, promo, stars }) => (
     <div className={styles.line}></div>
     <div className={styles.actions}>
       <div className={styles.outlines}>
-        <Button variant='outline'>
+        <Button variant='outline' className={isFavorite ? styles.active : ''}>
           <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
         </Button>
-        <Button variant='outline'>
+        <Button variant='outline' className={isCompared ? styles.active : ''}>
           <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
         </Button>
       </div>
@@ -61,6 +61,8 @@ ProductBox.propTypes = {
   price: PropTypes.number,
   promo: PropTypes.string,
   stars: PropTypes.number,
+  isFavorite: PropTypes.bool,
+  isCompared: PropTypes.bool,
 };
 
 export default ProductBox;

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -76,3 +76,13 @@
     align-items: center;
   }
 }
+
+.active {
+  background-color: $primary !important;
+  color: #ffffff !important;
+  border: 1px solid black !important;
+
+  svg {
+    color: #ffffff !important;
+  }
+}

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -15,6 +15,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      isFavorite: true,
+      isCompared: true,
     },
     {
       id: 'aenean-ru-bristique-2',
@@ -33,6 +35,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      isFavorite: true,
     },
     {
       id: 'aenean-ru-bristique-4',
@@ -51,6 +54,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      isCompared: true,
     },
     {
       id: 'aenean-ru-bristique-6',


### PR DESCRIPTION
#Co było nie tak?
Brakowało ostylowania przycisku "ulubiony" i "dodany do porównania"

#Co zrobiłem?
Poprawiłem stylowanie przycisków "ulubiony" oraz "dodany do porównania". Po otwarciu strony widoczny jest co najmniej jeden produkt z każdą z kombinacji:
bez żadnego aktywnego przycisku
tylko z aktywnym „ulubiony”
tylko z aktywnym „dodany do porównania”
z obiema aktywnymi opcjami.