### PR TITLE
WDP-2505-01 Bugfix: Dodanie obsługi starej ceny na karcie produktu

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -11,7 +11,7 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 
-const ProductBox = ({ name, price, promo, stars }) => (
+const ProductBox = ({ name, price, promo, stars, oldPrice }) => (
   <div className={styles.root}>
     <div className={styles.photo}>
       {promo && <div className={styles.sale}>{promo}</div>}
@@ -47,6 +47,7 @@ const ProductBox = ({ name, price, promo, stars }) => (
         </Button>
       </div>
       <div className={styles.price}>
+        {oldPrice && <span className={styles.oldPrice}>$ {oldPrice}</span>}
         <Button noHover variant='small'>
           $ {price}
         </Button>
@@ -61,6 +62,7 @@ ProductBox.propTypes = {
   price: PropTypes.number,
   promo: PropTypes.string,
   stars: PropTypes.number,
+  oldPrice: PropTypes.number,
 };
 
 export default ProductBox;

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -69,6 +69,18 @@
     }
   }
 
+  .price {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .oldPrice {
+      color: #888;
+      text-decoration: line-through black;
+      font-size: 14px;
+    }
+  }
+
   .actions {
     padding: 15px 10px 10px 10px;
     display: flex;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -24,6 +24,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      oldPrice: 40,
     },
     {
       id: 'aenean-ru-bristique-3',
@@ -42,6 +43,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      oldPrice: 50,
     },
     {
       id: 'aenean-ru-bristique-5',
@@ -60,6 +62,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      oldPrice: 440,
     },
     {
       id: 'aenean-ru-bristique-7',


### PR DESCRIPTION
Co nie działało? 
Na karcie produktu nie było możliwości wyświetlania starej ceny.

Co zrobiłem?
Dodałem do komponentu ProductBox możliwość przekazania i pokazania starej ceny, która jest teraz przekreślona i jest obok aktualnej. Dodałem też stylowanie do .oldPrice.