### PR TITLE
WDP250501-7 Select w wyszukiwaniu produktu w menu

### DIFF
--- a/src/components/features/ProductSearch/ProductSearch.module.scss
+++ b/src/components/features/ProductSearch/ProductSearch.module.scss
@@ -32,6 +32,15 @@
       padding: 5px 30px 5px 35px;
       position: relative;
       z-index: 1;
+      font-size: 14px;
+      outline: none;
+      height: 100%;
+
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.05);
+        cursor: pointer;
+        color: $text-color;
+      }
     }
   }
 

--- a/src/components/features/ProductSearch/ProductSearch.module.scss
+++ b/src/components/features/ProductSearch/ProductSearch.module.scss
@@ -37,7 +37,7 @@
       height: 100%;
 
       &:hover {
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: $search-hover-bg;
         cursor: pointer;
         color: $text-color;
       }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -11,3 +11,5 @@ $primary: #d58e32;
 $text-color: #2a2a2a;
 
 $form-border-color: #292929;
+
+$search-hover-bg: rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Link do zadania: 
https://projects.kodilla.com/browse/WDP250501-7

Co nie działało?
Select w formularzu wyszukiwania produktu był nieostylowany – miał nieodpowiedni rozmiar czcionki, brakowało efektów hover i pozostawał outline.

Co zrobiłem?
Ustawiłem odpowiedni rozmiar czcionki w elemencie select.
Usunąłem domyślny outline.
Dodałem efekt hover.