### PR TITLE
Dodano zmianę koloru ceny i wyświetlanie przycisków przy hoverze boxa produktu

### DIFF
--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -31,6 +31,10 @@
     .buttons {
       display: flex;
       justify-content: space-between;
+
+      opacity: 0;
+      pointer-events: none;
+
     }
   }
 
@@ -87,4 +91,22 @@
     justify-content: space-between;
     align-items: center;
   }
+
+  &:hover {
+    .photo {
+      .buttons {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
+
+    .actions {
+      .price {
+        > * {
+          background-color: $primary;
+        }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Zadanie: https://projects.kodilla.com/browse/WDP250501-4

Co nie działało?
- Buttony "Quick view" oraz "Add to cart" były widoczne cały czas, zamiast pojawiać się tylko przy najechaniu na box produktu.
- Tło ceny nie zmieniało się po najechaniu na box produktu

Co zrobiłam?
- Dodałam efekt hover na .root, który pokazuje przyciski "Quick view" i "Add to cart" oraz zmienia tło ceny wyłącznie podczas najechania na box konkretnego produktu.

