### PR TITLE
Dodano poprawki top bar i baner dla urzadzen mobilnych

### DIFF
--- a/src/components/layout/CompanyClaim/CompanyClaim.js
+++ b/src/components/layout/CompanyClaim/CompanyClaim.js
@@ -9,7 +9,7 @@ import { faMobileAlt, faShoppingBasket } from '@fortawesome/free-solid-svg-icons
 const CompanyClaim = () => (
   <div className={styles.root}>
     <div className='container'>
-      <div className='row align-items-center'>
+      <div className={'row align-items-center'}>
         <div className={`col text-left ${styles.phoneNumber}`}>
           <p>
             <FontAwesomeIcon className={styles.icon} icon={faMobileAlt} /> 2300 - 3560 -

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -71,3 +71,100 @@
     }
   }
 }
+
+@media (max-width: 480px) {
+  .root :global(.companyClaimRow) {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    column-gap: 1rem;
+    align-items: start;
+  }
+
+  .root :global(.companyClaimRow) > :global(.col.text-center) {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    text-align: left;
+  }
+
+  .root :global(.companyClaimRow) > :global(.col.text-right) {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .root :global(.companyClaimRow) > :global(.col.text-left) {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    justify-self: end;
+    font-size: 14px;
+
+    p {
+      margin: 0;
+      display: flex;
+      align-items: center;
+    }
+
+    .icon {
+      font-size: 18px;
+      margin-right: 0.5rem;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .root {
+    :global(.container) > :global(.row) {
+      padding: 15px 15px 15px 0;
+      margin-left:-2rem;
+    }
+
+    :global(.col.text-right) {
+      order: 2;
+      flex: 0 0 40%;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      margin-top: -1rem;
+    }
+
+    :global(.col.text-left) {
+      order: 3;
+      flex: 0 0 100%;
+      display:flex;
+      justify-content: flex-end;
+      margin-top: -0.5rem;
+
+      p {
+        font-size: 14px;
+
+        .icon {
+          font-size: 18px;
+        }
+      }
+    }
+    .cartIcon {
+      width: 55px;
+      height: 50px;
+    }
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -40,3 +40,28 @@
     }
   }
 }
+
+@media (max-width: 767px){
+  body, html {
+    overflow-x: hidden;
+  }
+  .topMenu ul li {
+    &:nth-child(1) a, &:nth-child(2) a {
+      font-size:0;
+
+      .icon {
+        font-size:13px;
+        margin-right:0;
+      }
+    }
+
+    &:nth-child(3) a {
+      font-size:13px;
+    }
+  }
+}
+
+
+
+
+


### PR DESCRIPTION
Zadanie: https://projects.kodilla.com/browse/WDP250501-15

Problem:
Strona sypie się w trybach responsive, zadanie dotyczy górnego paska (z walutą, językiem, etc.) oraz bannera na którym jest logo i inne elementy. 

Co zrobiłam:
- Ukryto teksty przy login/register, zostawiono same ikony
- Logo po lewej, koszyk wyrównany do góry logo, pod nim numer telefonu
- Zmieniono rozmiar numeru telefonu na 14px