### PR TITLE
WDP250501-20 Dodano zapisywanie trybu RWD w stanie aplikacji

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -15,25 +15,39 @@ class NewFurniture extends React.Component {
   }
 
   handleCategoryChange(newCategory) {
-    this.setState({ activeCategory: newCategory });
+    this.setState({ activeCategory: newCategory, activePage: 0 });
   }
 
   render() {
-    const { categories, products } = this.props;
+    const { categories, products, device } = this.props;
     const { activeCategory, activePage } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / 8);
+
+    //NOTE: wartości są orientacyjne - mogą się zmienić po wdrozeniu layoutu RWD z zadania 17
+    const itemsPerDevice = {
+      desktop:8,
+      tablet:3,
+      mobile:2,
+    }
+
+    const itemsPerPage = itemsPerDevice[device];
+    const pagesCount = Math.ceil(categoryProducts.length / itemsPerPage);
+
+    const visibleProducts = categoryProducts.slice(
+      activePage * itemsPerPage,
+      (activePage + 1) * itemsPerPage
+    );
 
     const dots = [];
     for (let i = 0; i < pagesCount; i++) {
       dots.push(
-        <li>
+        <li key={i}>
           <a
             onClick={() => this.handlePageChange(i)}
-            className={i === activePage && styles.active}
+            className={i === activePage ? styles.active : undefined}
           >
-            page {i}
+            page {i + 1}
           </a>
         </li>
       );
@@ -52,7 +66,7 @@ class NewFurniture extends React.Component {
                   {categories.map(item => (
                     <li key={item.id}>
                       <a
-                        className={item.id === activeCategory && styles.active}
+                        className={item.id === activeCategory ? styles.active : undefined}
                         onClick={() => this.handleCategoryChange(item.id)}
                       >
                         {item.name}
@@ -67,7 +81,7 @@ class NewFurniture extends React.Component {
             </div>
           </div>
           <div className='row'>
-            {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
+            {visibleProducts.map(item => (
               <div key={item.id} className='col-3'>
                 <ProductBox {...item} />
               </div>
@@ -98,6 +112,7 @@ NewFurniture.propTypes = {
       newFurniture: PropTypes.bool,
     })
   ),
+  device: PropTypes.string,
 };
 
 NewFurniture.defaultProps = {

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -15,7 +15,7 @@ class NewFurniture extends React.Component {
   }
 
   handleCategoryChange(newCategory) {
-    this.setState({ activeCategory: newCategory, activePage: 0 });
+    this.setState({ activeCategory: newCategory });
   }
 
   render() {
@@ -42,12 +42,12 @@ class NewFurniture extends React.Component {
     const dots = [];
     for (let i = 0; i < pagesCount; i++) {
       dots.push(
-        <li key={i}>
+        <li>
           <a
             onClick={() => this.handlePageChange(i)}
-            className={i === activePage ? styles.active : undefined}
+            className={i === activePage && styles.active}
           >
-            page {i + 1}
+            page {i}
           </a>
         </li>
       );
@@ -66,7 +66,7 @@ class NewFurniture extends React.Component {
                   {categories.map(item => (
                     <li key={item.id}>
                       <a
-                        className={item.id === activeCategory ? styles.active : undefined}
+                        className={item.id === activeCategory && styles.active}
                         onClick={() => this.handleCategoryChange(item.id)}
                       >
                         {item.name}

--- a/src/components/features/NewFurniture/NewFurnitureContainer.js
+++ b/src/components/features/NewFurniture/NewFurnitureContainer.js
@@ -4,10 +4,12 @@ import NewFurniture from './NewFurniture';
 
 import { getAll } from '../../../redux/categoriesRedux.js';
 import { getNew } from '../../../redux/productsRedux.js';
+import { getDevice } from '../../../redux/deviceRedux.js';
 
 const mapStateToProps = state => ({
   categories: getAll(state),
   products: getNew(state),
+  device: getDevice(state),
 });
 
 export default connect(mapStateToProps)(NewFurniture);

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -1,16 +1,42 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-
+import { useDispatch } from 'react-redux';
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
+import { setDevice } from '../../../redux/deviceRedux';
 
-const MainLayout = ({ children }) => (
-  <div>
-    <Header />
-    {children}
-    <Footer />
-  </div>
-);
+const MainLayout = ({ children }) => {
+
+  const dispatch=useDispatch();
+
+  useEffect(()=> {
+    const handleResize = () => {
+      const width = window.innerWidth;
+      if (width < 768) {
+        dispatch(setDevice('mobile'));
+      } else if (width < 1024) {
+        dispatch(setDevice('tablet'));
+      } else {
+        dispatch(setDevice('desktop'));
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [dispatch])
+
+  return (
+    <div>
+      <Header />
+      {children}
+      <Footer />
+    </div>
+  );
+
+}
+
 
 MainLayout.propTypes = {
   children: PropTypes.node,

--- a/src/redux/deviceRedux.js
+++ b/src/redux/deviceRedux.js
@@ -1,0 +1,21 @@
+import initialState from './initialState'
+
+const SET_DEVICE = 'SET_DEVICE';
+
+export const setDevice = (device) => ({
+    type:SET_DEVICE,
+    payload: device,
+});
+
+export const getDevice = (state) => state.device;
+
+const deviceReducer = (state = initialState.device, action) => {
+    switch(action.type) {
+        case SET_DEVICE:
+            return action.payload;
+        default:
+            return state;
+    }
+};
+
+export default deviceReducer;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -232,6 +232,7 @@ const initialState = {
   cart: {
     products: [],
   },
+  device:'desktop'
 };
 
 export default initialState;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,12 +4,14 @@ import initialState from './initialState';
 import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
+import deviceReducer from './deviceRedux';
 
 // define reducers
 const reducers = {
   cart: cartReducer,
   categories: categoriesReducer,
   products: productsReducer,
+  device: deviceReducer,
 };
 
 // add blank reducers for initial state properties without reducers


### PR DESCRIPTION
Zadanie: https://projects.kodilla.com/browse/WDP250501-20

Problem:
Komponent NewFurniture miał statyczną liczbę produktów na stronie - 8 niezależnie od urządzenia. Brakowało mechanizmu rozpoznającego urządzenie ( desktop/tablet/mobile) w celu dostosowania liczby widocznych produktów i paginacji.

Co zrobiłam:
- Utworzyłam plik deviceRedux.js, który zapisuje aktualny tryb urządzenia (desktop, tablet, mobile) w stanie aplikacji (Redux).
- W komponencie MainLayout dodałam logikę nasłuchującą zmiany rozmiaru okna i aktualizującą wartość device w store – działanie sprawdzone w Redux DevTools.
- W NewFurniture i NewFurnitureContainer wykorzystałam wartość device z redux do dynamicznego ustalania liczby elementów na stronie ( wstępnie: 8 na desktop, 3 na tabletach, 2 na mobilkach)
- W kodzie zostawiłam notatkę, że wartości itemsPerPage są orientacyjne i mogę ulec zmianie po wdrożeniu layoutu RWD w ramach zadania [WDP250501-17]-  moje zadanie dotyczyło wyłącznie logiki.

Efekt:
- Komponent NewFurniture dynamiczne dostosowuje liczbę widocznych produktów w zależności od aktualnej szerokości ekranu (trybu urządzenia)

