### PR TITLE
Fix RWD feature box

### DIFF
--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -14,31 +14,23 @@ import FeatureBox from '../../common/FeatureBox/FeatureBox';
 const FeatureBoxes = () => (
   <div className={styles.root}>
     <div className='container'>
-      <div className='row'>
-        <div className='col'>
-          <FeatureBox icon={faTruck}>
-            <h5>Free shipping</h5>
-            <p>All orders</p>
-          </FeatureBox>
-        </div>
-        <div className='col'>
-          <FeatureBox icon={faHeadphones}>
-            <h5>24/7 customer</h5>
-            <p>support</p>
-          </FeatureBox>
-        </div>
-        <div className='col'>
-          <FeatureBox icon={faReplyAll}>
-            <h5>Money back</h5>
-            <p>guarantee</p>
-          </FeatureBox>
-        </div>
-        <div className='col'>
-          <FeatureBox icon={faBullhorn}>
-            <h5>Member discount</h5>
-            <p>First order</p>
-          </FeatureBox>
-        </div>
+      <div className={styles.freeShippingBoxes}>
+        <FeatureBox icon={faTruck}>
+          <h5>Free shipping</h5>
+          <p>All orders</p>
+        </FeatureBox>
+        <FeatureBox icon={faHeadphones}>
+          <h5>24/7 customer</h5>
+          <p>support</p>
+        </FeatureBox>
+        <FeatureBox icon={faReplyAll}>
+          <h5>Money back</h5>
+          <p>guarantee</p>
+        </FeatureBox>
+        <FeatureBox icon={faBullhorn}>
+          <h5>Member discount</h5>
+          <p>First order</p>
+        </FeatureBox>
       </div>
     </div>
   </div>

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -1,5 +1,23 @@
 @import "../../../styles/settings.scss";
 
 .root {
-  padding: 5rem 0;
+  padding: 3rem 0;
+}
+
+.freeShippingBoxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  & > * {
+    flex: 1 1 calc(50% - 1rem);
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+@media (min-width: 992px) {
+  .freeShippingBoxes > * {
+    flex: 1 1 20%;
+  }
 }


### PR DESCRIPTION
Co było: 
- Na mobile i tablet karty ustawiały się w jednej kolumnie lub nierówno.
- Brakowało RWD, więc układ nie był dostosowany do mniejszych ekranów.
- karty miały różne wysokości elementów, co wyglądało nieestetycznie.

Co zrobiłem:
Wprowadziłem styl, który:
- wyświetla karty w 2 kolumnach na mobile/tablet (po 2 elementy w rzędzie)
- zmienia układ na 4 kolumny na desktopie
- zapewnia równą wysokość kart w rzędach.

Jira: https://projects.kodilla.com/browse/WDP250501-16